### PR TITLE
Select definitions on full match

### DIFF
--- a/TPHealth/TPHealth/scripts/overview.ts
+++ b/TPHealth/TPHealth/scripts/overview.ts
@@ -61,7 +61,7 @@ export class OverviewWidget {
 		var customSettings = <IOverviewSettings>JSON.parse(widgetSettings.customSettings.data);
 		var definitions = await buildClient.getDefinitions(context.project.name);
 		if (!!customSettings && !!customSettings.selectedDefinitions) {
-			definitions = definitions.filter(def => customSettings.selectedDefinitions.indexOf(def.name) != -1);
+			definitions = definitions.filter(def => customSettings.selectedDefinitions.split(", ").indexOf(def.name) != -1);
 		}
 
 		var ids = definitions.map(value => { return value.id });


### PR DESCRIPTION
Build definitions are only selected on full matches.
Build `Foo` will no longer be selected when build `Foo.Bar` is selected in the settings.

Thank you for your pull request!
By completing this pull request, you agree to the [Contributing License Agreement](https://github.com/ALM-Rangers/Visualize-Team-Project-Health-Widgets/blob/master/.github/CLA.md).

Fixes #5 .

@ALM-Rangers/Visualize-Team-Project-Health-Widgets
