### PR TITLE
Display builds not started in another color

### DIFF
--- a/extension/src/build-details.ts
+++ b/extension/src/build-details.ts
@@ -128,11 +128,14 @@ export class DetailsWidget {
 				$buildStatus.addClass("build-status-failed");
 				$buildDefinitionName.addClass("build-definition-name-failed");
 			}
-		} else if (build.status === TFS_Build_Contracts.BuildStatus.InProgress
-			|| build.status === TFS_Build_Contracts.BuildStatus.NotStarted) {
+		} else if (build.status === TFS_Build_Contracts.BuildStatus.InProgress) {
 			$root.addClass("building");
 			$buildStatus.addClass("build-status-building");
 			$buildDefinitionName.addClass("build-definition-name-building");
+		} else if (build.status === TFS_Build_Contracts.BuildStatus.NotStarted) {
+			$root.addClass("not-started");
+			$buildStatus.addClass("build-status-not-started");
+			$buildDefinitionName.addClass("build-definition-name-not-started");
 		}
 	}
 

--- a/extension/static/css/app.less
+++ b/extension/static/css/app.less
@@ -1,6 +1,7 @@
 @success: green;
 @fail: darkred;
 @partial: #cf7417;
+@not-started: #7489c9;
 @building: royalblue;
 @color: white;
 @no-builds-color: gray;
@@ -54,6 +55,10 @@
 
 .building {
     background-color: @building;
+}
+
+.not-started {
+    background-color: @not-started;
 }
 
 .imageContainer {
@@ -141,6 +146,10 @@ div {
         background-image: url('../img/refresh.gif');
 }
 
+.build-status-not-started {
+        background-image: url('../img/refresh.gif');
+}
+
 .build-status-failed {
         background-image: url('../img/cross.gif');
 }
@@ -150,14 +159,22 @@ div {
         background-color:@success !important;
     }
 }
+
 .build-definition-name-failed {
     &:after {
         background-color:@fail !important;
     }
 }
+
 .build-definition-name-building {
     &:after {
         background-color:@building !important;
+    }
+}
+
+.build-definition-name-not-started {
+    &:after {
+        background-color:@not-started !important;
     }
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:  

Display builds not started in another color (grayed blue) to be able to distinguish build running and build not started and waiting to build...

@ALM-Rangers/Visualize-Team-Project-Health-Widgets
