### PR TITLE
Add clickable screenshots links to manifest

### DIFF
--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -47,6 +47,17 @@
 			"version": "[15.3,)"
 		}
 	],
+	"screenshots": [
+	    {
+      		"path": "static/screenshots/builddetails.png"
+	    },
+	    {
+      		"path": "static/screenshots/buildoverview.png"
+	    },
+	    {
+      		"path": "static/screenshots/releasedetails.png"
+	    }
+	],	
 	"contributions": [
 		{
 			"id": "TPHealth-OverviewWidget",


### PR DESCRIPTION
Add existing screenshots to manifest such that they appear in right-hand side of marketplace as clickable links - example screenshot available here:  https://imgur.com/fbcVuka

Thank you for your pull request!
By completing this pull request, you agree to the [Contributing License Agreement](https://github.com/ALM-Rangers/Visualize-Team-Project-Health-Widgets/blob/master/.github/CLA.md).

Fixes # .

Changes proposed in this pull request:  
- 
- 
- 

@ALM-Rangers/Visualize-Team-Project-Health-Widgets
